### PR TITLE
Update remote_receiver.rst

### DIFF
--- a/components/remote_receiver.rst
+++ b/components/remote_receiver.rst
@@ -274,6 +274,8 @@ Remote code selection (exactly one of these has to be included):
 
   - **data** (**Required**, string): The code to listen for, see :ref:`remote_transmitter-transmit_raw`
     for more info. Usually you only need to copy this directly from the dumper output.
+  - **delta** (**Optional**, integer): The allowed delta between the specified code and the received
+    code. This allows you to manually correct receiving IR code from a 'sloppy' IR remote control.
 
 - **raw**: Trigger on a raw remote code with the given code.
 


### PR DESCRIPTION
Document new ``delta`` parameter

## Description:

Some universal IR remote controllers (I'm looking at you, Logitech...) that are able to learn IR codes from original remote controllers will send 'sloppy' IR signals that will be recognized by the original intended IR receiver hardware, but will not be picked up by the Pronto remote receiver code. This adds a ``delta`` to the Pronto specification that allows you to manually specify the delta you will allow to recognize an IR code.


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
